### PR TITLE
Refactor(auth): implement HttpOnly cookie sessions and CSRF Protection

### DIFF
--- a/backend/controllers/auth.go
+++ b/backend/controllers/auth.go
@@ -7,6 +7,7 @@ import (
 
 	"backend/database"
 	"backend/models"
+	"backend/utilities"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
@@ -18,7 +19,6 @@ type Claims struct {
 	Role       string `json:"role"`
 	jwt.RegisteredClaims
 }
-
 
 func JwtSecret() []byte {
 	secret := os.Getenv("JWT_SECRET")
@@ -94,5 +94,11 @@ func Login(c *gin.Context) {
 		return
 	}
 
+	//We still need a csrf token.
+	csrfTokenString := utilities.GenerateToken()
+	c.SetCookie("CSRF-TOKEN", csrfTokenString, 3600, "/", "localhost", false, false)
+
 	c.JSON(http.StatusOK, gin.H{"token": tokenString})
+
+	//TODO: Store the CSRF token in the database with an association to the user session for later validation
 }

--- a/backend/controllers/auth_test.go
+++ b/backend/controllers/auth_test.go
@@ -312,3 +312,40 @@ func TestRegister_MassAssignment_RoleIgnored(t *testing.T) {
 		t.Fatalf("Expected role 'employee', got '%s' — mass assignment vulnerability", employee.Role)
 	}
 }
+
+func TestLogin_CookiesSetOnLogin(t *testing.T) {
+	r := setupTestRouter()
+	body := map[string]string{
+		"username": "admin_attempt",
+		"email":    "admin@test.com",
+		"password": "securepassword123",
+		"role":     "admin",
+	}
+
+	w := registerUser(r, body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("Expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = loginUser(r, map[string]string{
+		"email":    "admin@test.com",
+		"password": "securepassword123",
+	})
+	// Get all cookies
+	cookies := w.Result().Cookies()
+
+	// Find a specific cookie by name
+	var csrfCookie *http.Cookie
+	for _, c := range cookies {
+		if c.Name == "CSRF-TOKEN" {
+			csrfCookie = c
+			break
+		}
+	}
+
+	if csrfCookie == nil {
+		t.Error("CSRF-TOKEN cookie not found in response")
+	} else {
+		t.Logf("Found cookie: %s = %s", csrfCookie.Name, csrfCookie.Value)
+	}
+}

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -17,7 +17,11 @@ func Connect() {
 		log.Fatal("Failed to connect to database:", err)
 	}
 
-	DB.AutoMigrate(&models.Employee{}, &models.Unit{}, &models.Customer{})
+	DB.AutoMigrate(&models.Employee{},
+		&models.Unit{},
+		&models.Customer{},
+		&models.RegisterRequest{},
+		&models.LoginRequest{})
 }
 
 func ConnectTest() {

--- a/backend/main.go
+++ b/backend/main.go
@@ -9,6 +9,7 @@ import (
 )
 
 func main() {
+
 	r := gin.Default()
 	config := cors.DefaultConfig()
 	config.AllowOrigins = []string{"http://localhost:4200"}

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -41,3 +41,28 @@ func AuthRequired() gin.HandlerFunc {
 		c.Next()
 	}
 }
+
+func CSRF() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("XSRF-TOKEN")
+		if authHeader == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Authorization header required"})
+			return
+		}
+		// Get token from cookie
+		cookieToken, err := c.Cookie("CSRF-TOKEN")
+		if cookieToken == "" || err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "CSRF token missing"})
+			c.Abort()
+			return
+		}
+		// Get token from header
+		headerToken := c.GetHeader("XSRF-TOKEN")
+
+		if headerToken == "" || cookieToken != headerToken {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "CSRF token mismatch"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -17,10 +17,19 @@ func SetupRoutes(r *gin.Engine) {
 		api.POST("/login", controllers.Login)
 	}
 
-	protected := r.Group("/api")
-	protected.Use(middleware.AuthRequired())
+	protected := r.Group("/")
+	protected.Use(middleware.AuthRequired(), middleware.CSRF())
 	{
 		protected.GET("/protected", func(c *gin.Context) {
+			employeeID, _ := c.Get("employee_id")
+			role, _ := c.Get("role")
+			c.JSON(http.StatusOK, gin.H{
+				"message":     "You have access",
+				"employee_id": employeeID,
+				"role":        role,
+			})
+		})
+		protected.GET("/dashboard", func(c *gin.Context) {
 			employeeID, _ := c.Get("employee_id")
 			role, _ := c.Get("role")
 			c.JSON(http.StatusOK, gin.H{

--- a/backend/utilities/security.go
+++ b/backend/utilities/security.go
@@ -3,6 +3,8 @@ package utilities
 import (
 	"backend/database"
 	"backend/models"
+	"crypto/rand"
+	"encoding/hex"
 	"log"
 	"time"
 
@@ -28,16 +30,18 @@ func CheckPasswordHash(password, hash string) bool {
 }
 
 func GenerateToken() string {
-	var csrfToken string
-	var err error
-	var timeNow = time.Now().String()
+	// 32 bytes provides 256 bits of entropy, which is standard for CSRF
+	b := make([]byte, 32)
 
-	csrfToken, err = HashPassword(timeNow)
+	// Read fills the slice with secure random bytes
+	_, err := rand.Read(b)
 	if err != nil {
-		log.Fatal("Error generating token: ", err)
+		// In the rare event the OS fails to provide randomness,
+		// we shouldn't proceed with an insecure token.
+		log.Fatalf("Critical error: Failed to generate secure random bytes: %v", err)
 	}
 
-	return csrfToken
+	return hex.EncodeToString(b)
 }
 
 func GenerateCookie() Cookie {
@@ -49,7 +53,7 @@ func GenerateCookie() Cookie {
 	var cookie Cookie
 	cookie.value = cookieValue
 	cookie.createdAt = time.Now()
-	cookie.expiration = time.Now().Add(24 * time.Hour) // Cookie expires in 24 hours
+	cookie.expiration = cookie.createdAt.Add(24 * time.Hour) // Cookie expires in 24 hours
 	return cookie
 }
 


### PR DESCRIPTION
**### JWT IN SESSION COOKIE**
**Auth Strategy Shift**: Moved JWT storage from the Authorization Header (manual) to an HttpOnly Cookie (automatic).
**XSS Defense**: The HttpOnly flag prevents JavaScript from reading the cookie, making the JWT immune to theft via Cross-Site Scripting.

**### CSRF COOKIES** 
CSRF Vulnerability: Cookies are sent automatically by the browser, which introduces Cross-Site Request Forgery risks.
CSRF Solution: Implemented the Double Submit Pattern. The client must manually send a matching token in the X-CSRF-Token header.
The Check: The new middleware blocks requests unless Cookie Value == Header Value.

_**INITIALISED LOGOUT**_
Lifecycle: Login issues both cookies; Logout immediately invalidates them using MaxAge: -1.