### PR TITLE
test: fix test isolation across all controller and service packages

### DIFF
--- a/backend/controllers/CRUD_test.go
+++ b/backend/controllers/CRUD_test.go
@@ -56,7 +56,7 @@ func boilerplate(t *testing.T, input any, req_type string, api string, r *gin.En
 }
 
 func TestGetAllCustomers(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -95,7 +95,7 @@ func TestGetAllCustomers(t *testing.T) {
 }
 
 func TestGetCustomer(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -129,7 +129,7 @@ func TestGetCustomer(t *testing.T) {
 }
 
 func TestUpdateCustomer(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -169,7 +169,7 @@ func TestUpdateCustomer(t *testing.T) {
 }
 
 func TestCreateCustomer(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	updatePayload := gin.H{
 		"FirstName": "John",
@@ -195,7 +195,7 @@ func TestCreateCustomer(t *testing.T) {
 }
 
 func TestDeleteCustomer(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -210,7 +210,7 @@ func TestDeleteCustomer(t *testing.T) {
 }
 
 func TestGetCustomerUnits(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -256,7 +256,7 @@ func TestGetCustomerUnits(t *testing.T) {
 }
 
 func TestGetAllUnits(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -282,7 +282,7 @@ func TestGetAllUnits(t *testing.T) {
 	}
 
 	// 2. Access the first customer in the list
-	firstUnit, ok := units[1].(map[string]interface{})
+	firstUnit, ok := units[0].(map[string]interface{})
 	if !ok {
 		t.Fatal("Customer data is not in the expected format")
 	}
@@ -295,7 +295,7 @@ func TestGetAllUnits(t *testing.T) {
 }
 
 func TestGetUnit(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -329,7 +329,7 @@ func TestGetUnit(t *testing.T) {
 }
 
 func TestUpdateUnit(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -367,7 +367,7 @@ func TestUpdateUnit(t *testing.T) {
 }
 
 func TestCreateUnit(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	updatePayload := gin.H{
 		"UnitNumber": "A123",
@@ -392,7 +392,7 @@ func TestCreateUnit(t *testing.T) {
 }
 
 func TestDeleteUnit(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	unit := models.Unit{
 		UnitNumber: "A123",
@@ -406,7 +406,7 @@ func TestDeleteUnit(t *testing.T) {
 }
 
 func TestDeleteNote(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -452,7 +452,7 @@ func TestDeleteNote(t *testing.T) {
 }
 
 func TestDeleteNote_Forbidden(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -497,7 +497,7 @@ func TestDeleteNote_Forbidden(t *testing.T) {
 }
 
 func TestDeleteNote_Manager(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -537,7 +537,7 @@ func TestDeleteNote_Manager(t *testing.T) {
 }
 
 func TestCreateNote(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -563,7 +563,7 @@ func TestCreateNote(t *testing.T) {
 }
 
 func TestGetNotes(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{
 		FirstName: "John",
@@ -597,7 +597,7 @@ func TestGetNotes(t *testing.T) {
 }
 
 func TestGetInsurance(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	unit := models.Unit{
 		UnitNumber: "INS-TEST-001",
@@ -629,7 +629,7 @@ func TestGetInsurance(t *testing.T) {
 }
 
 func TestCreateInsurance(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	unit := models.Unit{
 		UnitNumber: "INS-CREATE-001",
@@ -660,7 +660,7 @@ func TestCreateInsurance(t *testing.T) {
 }
 
 func TestUpdateInsurance(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	unit := models.Unit{
 		UnitNumber: "INS-UPDATE-001",
@@ -703,7 +703,7 @@ func TestUpdateInsurance(t *testing.T) {
 }
 
 //func TestCombineUnits(t *testing.T) {
-//	r := setupTestRouter()
+//	r := setupTestRouter(t)
 //
 //	customer := models.Customer{
 //		FirstName: "John",

--- a/backend/controllers/auth_test.go
+++ b/backend/controllers/auth_test.go
@@ -12,17 +12,19 @@ import (
 	"backend/middleware"
 	"backend/models"
 	"backend/services"
+	"backend/utilities"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/crypto/bcrypt"
 )
 
-func setupTestRouter() *gin.Engine {
+func setupTestRouter(t *testing.T) *gin.Engine {
 	gin.SetMode(gin.TestMode)
-	database.ConnectTest()
+	utilities.BcryptCost = bcrypt.MinCost
+	database.ConnectTest(t.Name())
 
-	hashed, _ := bcrypt.GenerateFromPassword([]byte("Manager123!"), 14)
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("Manager123!"), bcrypt.MinCost)
 	database.DB.Create(&models.Employee{
 		SMID:     "manager001",
 		Email:    "manager@suit.com",
@@ -141,7 +143,7 @@ func getCSRFToken(w *httptest.ResponseRecorder) string {
 
 // Vuln 1: Password must be bcrypt hashed in DB
 func TestRegister_PasswordIsHashed(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "hash_test",
@@ -164,7 +166,7 @@ func TestRegister_PasswordIsHashed(t *testing.T) {
 
 // Vuln 2: Login must return a JWT token in session_token cookie
 func TestLogin_ReturnsJWTToken(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "jwt_test",
@@ -198,7 +200,7 @@ func TestLogin_ReturnsJWTToken(t *testing.T) {
 
 // Vuln 2: Wrong password must return 401
 func TestLogin_WrongPassword_Returns401(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "wrong_pw",
@@ -218,7 +220,7 @@ func TestLogin_WrongPassword_Returns401(t *testing.T) {
 
 // Vuln 3: Protected route must reject requests without token
 func TestProtectedRoute_RejectsWithoutToken(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	req, _ := http.NewRequest("GET", "/api/protected", nil)
 	w := httptest.NewRecorder()
@@ -231,7 +233,7 @@ func TestProtectedRoute_RejectsWithoutToken(t *testing.T) {
 
 // Vuln 3: Protected route must accept valid session cookie
 func TestProtectedRoute_AcceptsValidToken(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "protected_test",
@@ -256,7 +258,7 @@ func TestProtectedRoute_AcceptsValidToken(t *testing.T) {
 
 // Vuln 4: Validation must reject invalid input
 func TestRegister_ValidationRejectsInvalidInput(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	tests := []struct {
 		name string
@@ -299,7 +301,7 @@ func TestRegister_ValidationRejectsInvalidInput(t *testing.T) {
 
 // Vuln 5: Password must not appear in JSON response
 func TestRegister_PasswordNotInResponse(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	w := registerUser(r, map[string]string{
 		"username": "no_pw_resp",
@@ -324,7 +326,7 @@ func TestRegister_PasswordNotInResponse(t *testing.T) {
 
 // Vuln 6: Duplicate email must return error
 func TestRegister_DuplicateEmail_ReturnsError(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "dup1",
@@ -345,7 +347,7 @@ func TestRegister_DuplicateEmail_ReturnsError(t *testing.T) {
 
 // Vuln 6: Nonexistent email must return 401
 func TestLogin_NonexistentEmail_Returns401(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	w := loginUser(r, map[string]string{
 		"email":    "nonexistent@test.com",
@@ -359,7 +361,7 @@ func TestLogin_NonexistentEmail_Returns401(t *testing.T) {
 
 // Vuln 7: Mass assignment must not allow setting role
 func TestRegister_MassAssignment_RoleIgnored(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	// Even if someone sends a "role" field, it should be ignored
 	body := map[string]string{
@@ -386,7 +388,7 @@ func TestRegister_MassAssignment_RoleIgnored(t *testing.T) {
 
 // Login must set session_token as HttpOnly cookie
 func TestLogin_SetsSessionCookie(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "session_test",
@@ -413,7 +415,7 @@ func TestLogin_SetsSessionCookie(t *testing.T) {
 
 // Login must set csrf_token as a non-HttpOnly cookie (JS readable)
 func TestLogin_SetsCSRFCookie(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "csrf_cookie_test",
@@ -442,7 +444,7 @@ func TestLogin_SetsCSRFCookie(t *testing.T) {
 
 // POST to protected route without X-CSRF-Token header must return 403
 func TestCSRF_BlocksPostWithoutToken(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "csrf_block_test",
@@ -468,7 +470,7 @@ func TestCSRF_BlocksPostWithoutToken(t *testing.T) {
 
 // GET to protected route should work without CSRF header (safe method)
 func TestCSRF_AllowsGetWithoutToken(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "csrf_get_test",
@@ -494,7 +496,7 @@ func TestCSRF_AllowsGetWithoutToken(t *testing.T) {
 
 // POST with valid X-CSRF-Token header must succeed
 func TestCSRF_AllowsPostWithValidToken(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "csrf_valid_test",
@@ -527,7 +529,7 @@ func TestCSRF_AllowsPostWithValidToken(t *testing.T) {
 
 // Logout must clear session and CSRF cookies
 func TestLogout_ClearsCookies(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "logout_test",
@@ -562,7 +564,7 @@ func TestLogout_ClearsCookies(t *testing.T) {
 
 // After logout, protected route must reject the request
 func TestLogout_ProtectedRouteFailsAfterLogout(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	registerUser(r, map[string]string{
 		"username": "logout_protect_test",
@@ -593,7 +595,7 @@ func TestLogout_ProtectedRouteFailsAfterLogout(t *testing.T) {
 }
 
 func TestSearchDB(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 	// Create test data
 	customer := models.Customer{
 		FirstName: "John",
@@ -664,7 +666,7 @@ func TestSearchDB(t *testing.T) {
 }
 
 func TestGetBalance(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	small, medium, large, xlarge := 50, 35, 25, 15
 
@@ -722,7 +724,7 @@ func TestGetBalance(t *testing.T) {
 }
 
 func TestGetTransactions(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	small, medium, large, xlarge := 50, 35, 25, 15
 
@@ -782,7 +784,7 @@ func TestGetTransactions(t *testing.T) {
 }
 
 func TestPortPayment(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	small, medium, large, xlarge := 50, 35, 25, 15
 

--- a/backend/controllers/controller.go
+++ b/backend/controllers/controller.go
@@ -910,7 +910,7 @@ func DeleteNote(c *gin.Context) {
 		return
 	}
 
-	noteIDStr := c.Param("note_id")
+	noteIDStr := c.Param("nid")
 	noteID, err := strconv.ParseUint(noteIDStr, 10, 64)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid note ID"})

--- a/backend/controllers/lockout_test.go
+++ b/backend/controllers/lockout_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetDeactivatedUnits(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{FirstName: "Grace", LastName: "Lee", Phone: "904-400-5000", Address: "7 Bay Ave", Email: "grace@test.com"}
 	database.DB.Create(&customer)
@@ -43,7 +43,7 @@ func TestGetDeactivatedUnits(t *testing.T) {
 }
 
 func TestGetDeactivatedUnits_NormalNotIncluded(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	database.DB.Create(&models.Unit{UnitNumber: "D2001", SizeType: "5x5", Price: 74.95, Length: 5, Width: 5, Height: 10, Combined: false, Status: models.UnitStatusNormal})
 

--- a/backend/controllers/moveout_test.go
+++ b/backend/controllers/moveout_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMoveOut(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{FirstName: "Eve", LastName: "Stone", Phone: "904-100-2000", Address: "5 River Rd", Email: "eve@test.com"}
 	database.DB.Create(&customer)
@@ -43,7 +43,7 @@ func TestMoveOut(t *testing.T) {
 }
 
 func TestMoveOut_NoRenter(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	unit := models.Unit{UnitNumber: "M2001", SizeType: "5x5", Price: 74.95, Length: 5, Width: 5, Height: 10, Combined: false, Status: models.UnitStatusNormal}
 	database.DB.Create(&unit)
@@ -57,7 +57,7 @@ func TestMoveOut_NoRenter(t *testing.T) {
 }
 
 func TestMoveOut_UnitNotFound(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 	login := loginUser(r, map[string]string{"email": "manager@suit.com", "password": "Manager123!"})
 	w := makeRequest(t, r, "POST", "/api/units/DOESNOTEXIST/moveout", nil, login)
 
@@ -67,7 +67,7 @@ func TestMoveOut_UnitNotFound(t *testing.T) {
 }
 
 func TestMoveOut_CancelsActiveReservation(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{FirstName: "Frank", LastName: "Hill", Phone: "904-200-3000", Address: "6 Lake Dr", Email: "frank@test.com"}
 	database.DB.Create(&customer)

--- a/backend/controllers/reservations_test.go
+++ b/backend/controllers/reservations_test.go
@@ -28,7 +28,7 @@ func makeRequest(t *testing.T, r interface{ ServeHTTP(http.ResponseWriter, *http
 }
 
 func TestCreateReservation(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{FirstName: "Alice", LastName: "Brown", Phone: "904-111-2222", Address: "1 Main St", Email: "alice@test.com"}
 	database.DB.Create(&customer)
@@ -59,7 +59,7 @@ func TestCreateReservation(t *testing.T) {
 }
 
 func TestCreateReservation_MissingField(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 	login := loginUser(r, map[string]string{"email": "manager@suit.com", "password": "Manager123!"})
 
 	w := makeRequest(t, r, "POST", "/api/reservations", map[string]interface{}{
@@ -73,7 +73,7 @@ func TestCreateReservation_MissingField(t *testing.T) {
 }
 
 func TestCreateReservation_BadCustomer(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 	login := loginUser(r, map[string]string{"email": "manager@suit.com", "password": "Manager123!"})
 
 	w := makeRequest(t, r, "POST", "/api/reservations", map[string]interface{}{
@@ -88,7 +88,7 @@ func TestCreateReservation_BadCustomer(t *testing.T) {
 }
 
 func TestGetReservations(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{FirstName: "Bob", LastName: "Green", Phone: "904-333-4444", Address: "2 Oak St", Email: "bob@test.com"}
 	database.DB.Create(&customer)
@@ -112,7 +112,7 @@ func TestGetReservations(t *testing.T) {
 }
 
 func TestCancelReservation(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{FirstName: "Carol", LastName: "White", Phone: "904-555-6666", Address: "3 Pine St", Email: "carol@test.com"}
 	database.DB.Create(&customer)
@@ -140,7 +140,7 @@ func TestCancelReservation(t *testing.T) {
 }
 
 func TestCancelReservation_NotFound(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 	login := loginUser(r, map[string]string{"email": "manager@suit.com", "password": "Manager123!"})
 
 	w := makeRequest(t, r, "DELETE", "/api/reservations/99999", nil, login)
@@ -150,7 +150,7 @@ func TestCancelReservation_NotFound(t *testing.T) {
 }
 
 func TestAssignAutoFulfillsReservation(t *testing.T) {
-	r := setupTestRouter()
+	r := setupTestRouter(t)
 
 	customer := models.Customer{FirstName: "Dan", LastName: "Black", Phone: "904-777-8888", Address: "4 Elm St", Email: "dan@test.com"}
 	database.DB.Create(&customer)

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -2,7 +2,9 @@ package database
 
 import (
 	"backend/models"
+	"fmt"
 	"log"
+	"strings"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -33,9 +35,16 @@ func Connect() {
 	//&models.LoginRequest{}, &models.CreateUnitRequest{})
 }
 
-func ConnectTest() {
+func ConnectTest(name string) {
+	if DB != nil {
+		if sqlDB, err := DB.DB(); err == nil {
+			sqlDB.Close()
+		}
+	}
 	var err error
-	DB, err = gorm.Open(sqlite.Open("file::memory:?cache=shared&_pragma=foreign_keys(1)"), &gorm.Config{})
+	safe := strings.NewReplacer("/", "_", " ", "_").Replace(name)
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared&_pragma=foreign_keys(1)", safe)
+	DB, err = gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
 		log.Fatal("Failed to connect to test database:", err)
 	}

--- a/backend/database/init.go
+++ b/backend/database/init.go
@@ -12,9 +12,7 @@ func Init() {
 }
 
 func DevInit(small int, medium int, large int, xlarge int, testing ...any) {
-	if len(testing) > 0 {
-		ConnectTest()
-	} else {
+	if len(testing) == 0 {
 		Connect()
 	}
 	var count int64

--- a/backend/database/init_test.go
+++ b/backend/database/init_test.go
@@ -11,6 +11,7 @@ func Test_Init(t *testing.T) {
 	small, medium, large, xlarge := 50, 35, 25, 15
 	var count int64
 
+	database.ConnectTest(t.Name())
 	database.DevInit(small, medium, large, xlarge, true)
 
 	database.DB.Model(&models.Unit{}).Where("size_type = ?", "5x5").Count(&count)
@@ -41,6 +42,7 @@ func Test_Init(t *testing.T) {
 func Test_Insert_Customers(t *testing.T) {
 	small, medium, large, xlarge := 50, 35, 25, 15
 
+	database.ConnectTest(t.Name())
 	database.DevInit(small, medium, large, xlarge, true)
 	database.InsertCustomers()
 

--- a/backend/services/billing_test.go
+++ b/backend/services/billing_test.go
@@ -13,6 +13,7 @@ import (
 func TestCreateCharge(t *testing.T) {
 	small, medium, large, xlarge := 50, 35, 25, 15
 
+	database.ConnectTest(t.Name())
 	database.DevInit(small, medium, large, xlarge, true)
 
 	// 1. Setup Mock Data
@@ -41,6 +42,7 @@ func TestCreateCharge(t *testing.T) {
 func TestRecordPaymentAndBalance(t *testing.T) {
 	small, medium, large, xlarge := 50, 35, 25, 15
 
+	database.ConnectTest(t.Name())
 	database.DevInit(small, medium, large, xlarge, true)
 	db := database.DB
 
@@ -70,6 +72,7 @@ func TestRecordPaymentAndBalance(t *testing.T) {
 func TestOverpayment(t *testing.T) {
 	small, medium, large, xlarge := 50, 35, 25, 15
 
+	database.ConnectTest(t.Name())
 	database.DevInit(small, medium, large, xlarge, true)
 	db := database.DB
 	cust := models.Customer{FirstName: "Rich", LastName: "Uncle"}
@@ -88,6 +91,7 @@ func TestOverpayment(t *testing.T) {
 func TestUnderpayment(t *testing.T) {
 	small, medium, large, xlarge := 50, 35, 25, 15
 
+	database.ConnectTest(t.Name())
 	database.DevInit(small, medium, large, xlarge, true)
 	db := database.DB
 	cust := models.Customer{FirstName: "Poor", LastName: "Timmy"}
@@ -106,6 +110,7 @@ func TestUnderpayment(t *testing.T) {
 func TestTransactionRollback(t *testing.T) {
 	small, medium, large, xlarge := 50, 35, 25, 15
 
+	database.ConnectTest(t.Name())
 	database.DevInit(small, medium, large, xlarge, true)
 	db := database.DB
 
@@ -124,6 +129,7 @@ func TestTransactionRollback(t *testing.T) {
 func TestCheckAndProcessStorageBilling(t *testing.T) {
 	// 1. Setup - Using your DevInit sizes
 	small, medium, large, xlarge := 50, 35, 25, 15
+	database.ConnectTest(t.Name())
 	database.DevInit(small, medium, large, xlarge, true)
 	db := database.DB
 

--- a/backend/services/reports_test.go
+++ b/backend/services/reports_test.go
@@ -5,6 +5,7 @@ import (
 	"backend/database"
 	"backend/middleware"
 	"backend/models"
+	"backend/utilities"
 	"bytes"
 	"encoding/json"
 	"net/http"
@@ -17,11 +18,12 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-func setupTestRouter() *gin.Engine {
+func setupTestRouter(t *testing.T) *gin.Engine {
 	gin.SetMode(gin.TestMode)
-	database.ConnectTest()
+	utilities.BcryptCost = bcrypt.MinCost
+	database.ConnectTest(t.Name())
 
-	hashed, _ := bcrypt.GenerateFromPassword([]byte("Manager123!"), 14)
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("Manager123!"), bcrypt.MinCost)
 	database.DB.Create(&models.Employee{
 		SMID:     "manager001",
 		Email:    "manager@suit.com",
@@ -110,7 +112,7 @@ func TimePtr(t time.Time) *time.Time {
 
 func TestUtilPDFDownload(t *testing.T) {
 	// 1. Setup Router and Mock Data
-	r := setupTestRouter() // Your Gin engine
+	r := setupTestRouter(t) // Your Gin engine
 	database.DevInit(25, 25, 25, 25, true)
 	api := "forms/util"
 	req_type := "GET"

--- a/backend/utilities/security.go
+++ b/backend/utilities/security.go
@@ -7,9 +7,11 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+var BcryptCost = 14
+
 // HashPassword takes a plaintext password and returns the bcrypt hash of it
 func HashPassword(password string) (string, error) {
-	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 14)
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), BcryptCost)
 	return string(bytes), err
 }
 


### PR DESCRIPTION
Each test now opens its own named in-memory SQLite database keyed by t.Name(), preventing data from one test leaking into another. Closes connection before reopening to avoid goroutine exhaustion.

Also exports BcryptCost from utilities so tests can use bcrypt.MinCost and avoid bcrypt-14 hashing times blowing the 120s timeout.

Fix DeleteNote handler reading wrong Gin param name (note_id vs nid). Fix TestGetAllUnits indexing units[1] when only 1 unit was seeded.